### PR TITLE
Fix buffer size issue

### DIFF
--- a/plsql/xutl_flatfile.pkb
+++ b/plsql/xutl_flatfile.pkb
@@ -256,7 +256,7 @@ create or replace package body xutl_flatfile is
       dbms_lob.read(stream.content, amount, stream.offset, buf.content);
       stream.offset := stream.offset + amount;
       stream.available := stream.available - amount;
-      buf.sz := amount;
+      buf.sz := length(buf.content); -- Read actual length, as can be less than amount particularly if stream.content contains Unicode Supplementary Characters
       buf.offset := 1;
     else
       buf.content := null;
@@ -606,7 +606,7 @@ create or replace package body xutl_flatfile is
       dbms_lob.read(stream.content, amount, stream.offset, buf.content);
       stream.offset := stream.offset + amount;
       stream.available := stream.available - amount;
-      buf.sz := amount;
+      buf.sz := length(buf.content); -- Can be less than amount
       buf.offset := 1;
       buf.available := buf.sz;
     exception

--- a/plsql/xutl_flatfile.pks
+++ b/plsql/xutl_flatfile.pks
@@ -27,7 +27,7 @@ create or replace package xutl_flatfile is
     Change history :
     Marc Bleron       2019-05-21     Creation
     Marc Bleron       2022-11-15     Various fixes in read_fields function
-    Paul Scott        2015-04-03     Fix buffer size issue and exported column mapping helper routines
+    Paul Scott        2025-04-03     Fix buffer size issue and exported column mapping helper routines
 ====================================================================================== */
 
   -- Flat File constants

--- a/plsql/xutl_flatfile.pks
+++ b/plsql/xutl_flatfile.pks
@@ -27,6 +27,7 @@ create or replace package xutl_flatfile is
     Change history :
     Marc Bleron       2019-05-21     Creation
     Marc Bleron       2022-11-15     Various fixes in read_fields function
+    Paul Scott        2015-04-03     Fix buffer size issue and exported column mapping helper routines
 ====================================================================================== */
 
   -- Flat File constants
@@ -44,6 +45,14 @@ create or replace package xutl_flatfile is
   DEFAULT_LINE_TERM      constant varchar2(2) := FF_CRLF;
   DEFAULT_TEXT_QUAL      constant varchar2(1) := FF_QUOTATION_MARK;
   
+  -- Column mapping helper routines
+  function base26encode (colNum in pls_integer)
+  return varchar2;
+
+  function base26decode (colRef in varchar2)
+  return pls_integer;
+
+  -- Context / parsing routines
   function new_context (
     p_content  in clob
   , p_cols     in varchar2


### PR DESCRIPTION
Fixed buffer size issue, which caused parsing failures particularly when CSV data contained Unicode Supplementary Characters.

Also exported column mapping helper routines, to help when callers are working with ordinal column positions.

Buffer issue example:

declare
  vclob clob := to_clob(unistr('\D83D\DCCDthis is a test\D83C\DF43'));
  buffer varchar2(32767);
  amount integer := 18;
begin
  dbms_lob.read(vclob, amount, 1, buffer);
  dbms_output.put_line( 'amount = ' || amount || ', buffer len = ' || length(buffer));
end;
/

amount = 18, buffer len = 16